### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Then in the layout of your activity you must give it a background like this;
 Include this line in your gradle build file:
 
 ```groovy
-compile 'com.r0adkll:slidableactivity:2.0.6'
+implementation 'com.r0adkll:slidableactivity:2.0.6'
 ```
 
 <!--  


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.